### PR TITLE
Fixing syntax mistake, clarifying why pillar don’t work

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Salt-API and Reactor Formula
 
 ## Purpose
 
-The purpose of this formula is to allow you to call Saltstack via simple HTTP webhooks. You can use this formula for complicated setups like integrating your own application into Saltstack or for simple day to day tasks like having a provisioning script send a webhook to accept a new minion key. 
+The purpose of this formula is to allow you to call Saltstack via simple HTTP webhooks. You can use this formula for complicated setups like integrating your own application into Saltstack or for simple day to day tasks like having a provisioning script send a webhook to accept a new minion key.
 
 ### A bit of background
 
@@ -27,6 +27,11 @@ This system uses a specific key for authenticating requests, the key is defined 
 **Replace this with something better:**
 
     {% if postdata.secretkey == "PICKSOMETHINGBETTERPLZKTHX" %}
+
+Note that even though the reactor files are in `/srv/salt/reactor/`, they [aren’t run in the same fashion as a state](http://salt-api.readthedocs.org/en/latest/ref/netapis/all/saltapi.netapi.rest_cherrypy.html#saltapi.netapi.rest_cherrypy.app.Webhook) file would be.
+In other words, you can’t expect to have access to pillar or grains from there.
+If you want to make your reactor file to use a secret key that you store in pillars, you’d have to make the reactor files as `file.managed` with `template: ...`, and make it generate it for you with the appropriate key, at the place where your master configuration at `reactor:` would expect them.
+
 
 ## Usage
 

--- a/reactor/services/init.sls
+++ b/reactor/services/init.sls
@@ -8,6 +8,6 @@ service_init:
     - expr_form: {{ postdata.matcher }}
     {% endif %}
     - arg:
-      - {{ postdata.args }}
+      - {{ postdata.service }}
 {% endif %}
-  
+

--- a/reactor/services/reload.sls
+++ b/reactor/services/reload.sls
@@ -8,6 +8,6 @@ services_reload:
     - expr_form: {{ postdata.matcher }}
     {% endif %}
     - arg:
-      - {{ postdata.args }}
+      - {{ postdata.service }}
 {% endif %}
-  
+

--- a/reactor/services/restart.sls
+++ b/reactor/services/restart.sls
@@ -8,6 +8,6 @@ services_restart:
     - expr_form: {{ postdata.matcher }}
     {% endif %}
     - arg:
-      - {{ postdata.args }}
+      - {{ postdata.service }}
 {% endif %}
-  
+

--- a/reactor/services/start.sls
+++ b/reactor/services/start.sls
@@ -8,6 +8,6 @@ services_start:
     - expr_form: {{ postdata.matcher }}
     {% endif %}
     - arg:
-      - {{ postdata.args }}
+      - {{ postdata.service }}
 {% endif %}
-  
+

--- a/reactor/services/stop.sls
+++ b/reactor/services/stop.sls
@@ -8,6 +8,6 @@ services_stop:
     - expr_form: {{ postdata.matcher }}
     {% endif %}
     - arg:
-      - {{ postdata.args }}
+      - {{ postdata.service }}
 {% endif %}
-  
+


### PR DESCRIPTION
I’ve spent time trying it out, its great! Except I found a small syntax error :)

While thinking how to use it, I thought we’d like to parametrize the `secretkey` and realized too late that reactors can’t get access to it. I adjusted the readme to give a solution path on how to parametrize it.
